### PR TITLE
Fix url to file and simplified encoding of filename

### DIFF
--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -9,7 +9,7 @@ class LogViewerController extends \Illuminate\Routing\Controller
     public function index()
     {
         if (\Input::get('l')) {
-            LaravelLogViewer::setFile(\Crypt::decrypt(\Input::get('l')));
+            LaravelLogViewer::setFile(base64_decode(\Input::get('l')));
         }
 
         $logs = LaravelLogViewer::all();

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -43,14 +43,14 @@
     </style>
   </head>
   <body>
-    <div class="container-fluid"">
+    <div class="container-fluid">
       <div class="row">
         <div class="col-sm-3 col-md-2 sidebar">
           <h1><span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> Laravel Log Viewer</h1>
           <p class="text-muted"><i>by Rap2h</i></p>
           <div class="list-group">
             @foreach($files as $file)
-              <a href="{{{ Request::url() }}}/?l={{{ Crypt::encrypt($file) }}}" class="list-group-item @if ($current_file == $file) llv-active @endif">
+              <a href="?l={{ base64_encode($file) }}" class="list-group-item @if ($current_file == $file) llv-active @endif">
                 {{$file}}
               </a>
             @endforeach


### PR DESCRIPTION
This fixes issue with url pointing to wrong base path when app is installed in e.g. `localhost/my-app/public/`

Also simplified usage of encoding filenames, no need to encrypt it.