### PR TITLE
Removed paging from logging

### DIFF
--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -96,7 +96,8 @@
     <script>
       $(document).ready(function(){
         $('#table-log').DataTable({
-          "order": [ 1, 'desc' ]
+          "order"  : [ 1, 'desc' ],
+          "paging" : false
         });
         $('.table-container').on('click', '.expand', function(){
           $('#' + $(this).data('display')).toggle();


### PR DESCRIPTION
Not sure that pagination is really needed for this log viewer? 
Though I would suggest removing it. There is no real performance gain since it is client side anyways.