### PR TITLE
Adding error handling for instances where regex does not find required elements

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -102,8 +102,8 @@ class LaravelLogViewer
                                 'level' => $ll,
                                 'level_class' => $levels_classes[$ll],
                                 'level_img' => $levels_imgs[$ll],
-                                'date' => $current[1],
-                                'text' => $current[2],
+                                'date' => isset($current[1]) ? $current[1] : null,
+                                'text' => isset($current[2]) ? $current[2] : null,
                                 'in_file' => isset($current[3]) ? $current[3] : null,
                                 'stack' => preg_replace("/^\n*/", '', $log_data[$i])
                             );


### PR DESCRIPTION
Upon installing in Laravel 4.2, the log viewer threw an exception because one line failed to populate the $current array from the regex. These changes allow it to keep going when this happens and render the page properly.