### PR TITLE
Filter out any directories within the logs folder.

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -124,12 +124,13 @@ class LaravelLogViewer
     {
         $files = glob(storage_path() . '/logs/*');
         $files = array_reverse($files);
+        $files = array_filter($files, 'is_file');
         if ($basename && is_array($files)) {
             foreach ($files as $k => $file) {
                 $files[$k] = basename($file);
             }
         }
-        return $files;
+        return array_values($files);
     }
 
     /**


### PR DESCRIPTION
If storage/logs had directories in it, exceptions were being thrown. This just filters out directories so they don't display on the sidebar at all.