### PR TITLE
Add ability to add log files with absolute path.

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -46,8 +46,17 @@ class LaravelLogViewer
      */
     public static function setFile($file)
     {
-        if (File::exists(storage_path() . '/logs/' . $file)) {
-            self::$file = storage_path() . '/logs/' . $file;
+        // if absolute path is given
+        if (File::exists($file)) {
+            self::$file = $file;
+
+        // or check if file with given filename is in storage/logs folder
+        } else {
+            $file = storage_path() . '/logs/' . $file;
+
+            if (File::exists($file)) {
+                self::$file = $file;
+            }
         }
     }
 
@@ -69,7 +78,7 @@ class LaravelLogViewer
         $log_levels = self::getLogLevels();
 
         $pattern = '/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\].*/';
-        
+
         if (!self::$file) {
             $log_file = self::getFiles();
             if(!count($log_file)) {


### PR DESCRIPTION
In the [documentation](http://laravel.com/docs/5.1/errors#configuration) there's not only options for storing log files inside the app as `single` and `daily`, but options for storing errors to system logs: `syslog` and `errorlog`.

In my case `errorlog` is used. So all errors from Laravel are saved to `/var/logs/nginx/<project-name>-error.log`

In order to have ability to read that log I should make my custom controller with one line which specify path to my errorlog:

    LaravelLogViewer::setFile('/var/log/nginx/<project-name>-error.log');

This PR allows to set absolute and relative log files as well. 