### PR TITLE
validate log file path

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -46,18 +46,27 @@ class LaravelLogViewer
      */
     public static function setFile($file)
     {
-        // if absolute path is given
+        $file = self::pathToLogFile($file);
+
         if (File::exists($file)) {
             self::$file = $file;
-
-        // or check if file with given filename is in storage/logs folder
-        } else {
-            $file = storage_path() . '/logs/' . $file;
-
-            if (File::exists($file)) {
-                self::$file = $file;
-            }
         }
+    }
+
+    public static function pathToLogFile($file)
+    {
+        $logsPath = storage_path('logs');
+
+        if (! File::exists($file)) { // try the absolute path
+            $file = $logsPath . '/' . $file;
+        }
+
+        // check if requested file is really in the logs directory
+        if (dirname($file) !== $logsPath) {
+            throw new \Exception('No such log file');
+        }
+
+        return $file;
     }
 
     /**

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -16,13 +16,13 @@ class LogViewerController extends Controller
     public function index()
     {
 
-        if (Input::get('l')) {
+        if (Request::input('l')) {
             LaravelLogViewer::setFile(base64_decode(Request::input('l')));
         }
 
-        if (Input::get('dl')) {
+        if (Request::input('dl')) {
             return Response::download(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('dl'))));
-        } elseif (Input::has('del')) {
+        } elseif (Request::has('del')) {
             File::delete(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('del'))));
             return Redirect::to(Request::url());
         }

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
-use Input;
-
 
 class LogViewerController extends Controller
 {

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -17,13 +17,13 @@ class LogViewerController extends Controller
     {
 
         if (Input::get('l')) {
-            LaravelLogViewer::setFile(base64_decode(Input::get('l')));
+            LaravelLogViewer::setFile(base64_decode(Request::input('l')));
         }
 
         if (Input::get('dl')) {
-            return Response::download(LaravelLogViewer::pathToLogFile(base64_decode(Input::get('dl'))));
+            return Response::download(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('dl'))));
         } elseif (Input::has('del')) {
-            File::delete(LaravelLogViewer::pathToLogFile(base64_decode(Input::get('del'))));
+            File::delete(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('del'))));
             return Redirect::to(Request::url());
         }
 

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
+use Input;
 
 
 class LogViewerController extends Controller
@@ -14,14 +15,15 @@ class LogViewerController extends Controller
 
     public function index()
     {
-        if (Request::input('l')) {
-            LaravelLogViewer::setFile(base64_decode(Request::input('l')));
+
+        if (Input::get('l')) {
+            LaravelLogViewer::setFile(base64_decode(Input::get('l')));
         }
 
-        if (Request::input('dl')) {
-            return Response::download(storage_path() . '/logs/' . base64_decode(Request::input('dl')));
-        } elseif (Request::has('del')) {
-            File::delete(storage_path() . '/logs/' . base64_decode(Request::input('del')));
+        if (Input::get('dl')) {
+            return Response::download(LaravelLogViewer::pathToLogFile(base64_decode(Input::get('dl'))));
+        } elseif (Input::has('del')) {
+            File::delete(LaravelLogViewer::pathToLogFile(base64_decode(Input::get('del'))));
             return Redirect::to(Request::url());
         }
 
@@ -33,5 +35,4 @@ class LogViewerController extends Controller
             'current_file' => LaravelLogViewer::getFileName()
         ]);
     }
-
 }

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -8,7 +8,7 @@
 
     <!-- Bootstrap -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="//cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.css">
 
 
 
@@ -98,8 +98,8 @@
     </div>
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="//cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
-    <script src="//cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.js"></script>
+    <script src="https://cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/plug-ins/9dcbecd42ad/integration/bootstrap/3/dataTables.bootstrap.js"></script>
     <script>
       $(document).ready(function(){
         $('#table-log').DataTable({


### PR DESCRIPTION
The path given as query parameters aren't validated. To prevent accessing files outside of the log directory this patch validates the file names.

I've fixed this mainly to avoid something like: http.../logs?dl=Li4vLi4vLmVudg==