### PR TITLE
Fix using log files with absolute path

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -57,9 +57,11 @@ class LaravelLogViewer
     {
         $logsPath = storage_path('logs');
 
-        if (! File::exists($file)) { // try the absolute path
-            $file = $logsPath . '/' . $file;
+        if (File::exists($file)) { // try the absolute path
+            return $file;
         }
+
+        $file = $logsPath . '/' . $file;
 
         // check if requested file is really in the logs directory
         if (dirname($file) !== $logsPath) {


### PR DESCRIPTION
This PR recovers using log files with absolute path, e.g. 

```php
LaravelLogViewer::setFile('/var/log/nginx/<project-name>-error.log');
```

This was working after merging https://github.com/rap2hpoutre/laravel-log-viewer/pull/47, but broken in https://github.com/rap2hpoutre/laravel-log-viewer/commit/44f7fbb13eabc0d1571455b3e68a812a617c3691