### PR TITLE
Add Log context to table

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -117,17 +117,18 @@ class LaravelLogViewer
                 foreach ($log_levels as $level_key => $level_value) {
                     if (strpos(strtolower($h[$i]), '.' . $level_value)) {
 
-                        preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\].*?\.' . $level_key . ': (.*?)( in .*?:[0-9]+)?$/', $h[$i], $current);
+                        preg_match('/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\].*?(\w+)\.' . $level_key . ': (.*?)( in .*?:[0-9]+)?$/', $h[$i], $current);
 
-                        if (!isset($current[2])) continue;
+                        if (!isset($current[3])) continue;
 
                         $log[] = array(
+                            'context' => $current[2],
                             'level' => $level_value,
                             'level_class' => self::$levels_classes[$level_value],
                             'level_img' => self::$levels_imgs[$level_value],
                             'date' => $current[1],
-                            'text' => $current[2],
-                            'in_file' => isset($current[3]) ? $current[3] : null,
+                            'text' => $current[3],
+                            'in_file' => isset($current[4]) ? $current[4] : null,
                             'stack' => preg_replace("/^\n*/", '', $log_data[$i])
                         );
                     }

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -66,6 +66,7 @@
             <thead>
               <tr>
                 <th>Level</th>
+                <th>Context</th>
                 <th>Date</th>
                 <th>Content</th>
               </tr>
@@ -75,6 +76,7 @@
 @foreach($logs as $key => $log)
 <tr>
   <td class="text-{{{$log['level_class']}}}"><span class="glyphicon glyphicon-{{{$log['level_img']}}}-sign" aria-hidden="true"></span> &nbsp;{{$log['level']}}</td>
+  <td class="text">{{$log['context']}}</td>
   <td class="date">{{{$log['date']}}}</td>
   <td class="text">
     @if ($log['stack']) <a class="pull-right expand btn btn-default btn-xs" data-display="stack{{{$key}}}"><span class="glyphicon glyphicon-search"></span></a>@endif


### PR DESCRIPTION
Hopefully I've done this in a manner you would agree with; I thought about using a second preg_match to get the context since that wouldn't disrupt the $current variable IDs, but this seems cleaner than that.

I've tested this locally in my setup and things seem to work out as I would expect. Let me know if you'd like me to make adjustments so that this can be merged in.