### PR TITLE
Make routes location generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add Service Provider to `config/app.php` in `providers` section
 Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider::class,
 ```
 
-Add a route in `app/Http/routes.php` (or choose another route): 
+Add a route in your web routes file: (or choose another route): 
 ```php 
 Route::get('logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
 ```


### PR DESCRIPTION
In the latest version of Laravel, web routes now lives in `app/routes/web.php`. 

This proposed change makes the reference to the routes location generic, so it could apply to both the latest versions of Laravel or what it is in Laravel 5.1 (LTS) (`app/Http/routes.php`).