### PR TITLE
Use "redirect" helper function to support Lumen's Redirector.

### DIFF
--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -27,7 +27,7 @@ class LogViewerController extends BaseController
             return Response::download(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('dl'))));
         } elseif (Request::has('del')) {
             File::delete(LaravelLogViewer::pathToLogFile(base64_decode(Request::input('del'))));
-            return Redirect::to(Request::url());
+            return $this->redirect(Request::url());
         }
 
         $logs = LaravelLogViewer::all();
@@ -37,5 +37,14 @@ class LogViewerController extends BaseController
             'files' => LaravelLogViewer::getFiles(true),
             'current_file' => LaravelLogViewer::getFileName()
         ]);
+    }
+
+    private function redirect($to)
+    {
+        if (function_exists('redirect')) {
+            return redirect($to);
+        }
+
+        return Redirect::to($to);
     }
 }


### PR DESCRIPTION
Solves #75

`Class redirect does not exist` error when deleting a log file.

The problem is caused because:

> Since version 5.2, Lumen uses a different Redirector class (other than Illuminate's) and no longer offers a container alias for the Redirector class or the Redirect Facade out of the box.

I've implemented your suggestion

> Maybe we should use redirect() if it exists and Redirect facade if not?

Tested with a fresh installation of 
- Laravel versions 4.2 and 5.3. 
- Lumen versions 5.1, 5.2, and 5.3.