### PR TITLE
Added ability to publish log.blade.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Route::get('logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
 
 Go to `http://myapp/logs` or some other route
 
+**Optionally** publish `log.blade.php` into `/resources/views/vendor/laravel-log-viewer/` for easy customization:
+
+```
+php artisan vendor:publish --provider="Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider" --tag=views
+``` 
+
 Install (Lumen)
 ---------------
 

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -25,6 +25,12 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
 		if (method_exists($this, 'loadViewsFrom')) {
 			$this->loadViewsFrom(__DIR__.'/../../views', 'laravel-log-viewer');
 		}
+		
+		if (method_exists($this, 'publishes')) {
+		    $this->publishes([
+		       	__DIR__.'/../../views' => base_path('/resources/views/vendor/laravel-log-viewer'),
+		    ], 'views');
+		}
 	}
 
 	/**


### PR DESCRIPTION
Added ability to publish log.blade.php into `/resources/views/vendor/laravel-log-viewer/` and updated readme accordingly.


```
php artisan vendor:publish --provider="Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider" --tag=views
``` 
