### PR TITLE
fix pathToLogFile to only get files in log dir

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -78,16 +78,14 @@ class LaravelLogViewer
      */
     public static function pathToLogFile($file)
     {
-        $logsPath = storage_path('logs');
+        if (!starts_with('/', $file)) {
+            $logsPath = storage_path('logs');
 
-        if (app('files')->exists($file)) { // try the absolute path
-            return $file;
+            $file = $logsPath . '/' . $file;
         }
 
-        $file = $logsPath . '/' . $file;
-
         // check if requested file is really in the logs directory
-        if (dirname($file) !== $logsPath) {
+        if (dirname(realpath($file)) !== $logsPath) {
             throw new \Exception('No such log file');
         }
 


### PR DESCRIPTION
Proper check the file parameter to disallow arbitrary file downloads. Didn't I fix this issue already a while ago?