### PR TITLE
Append the old query strings when switching tabs to view other files

### DIFF
--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -35,10 +35,13 @@ class LogViewerController extends BaseController
             return $this->redirect($this->request->url());
         }
 
+        $uri = $this->request->getRequestUri();
+
         return app('view')->make('laravel-log-viewer::log', [
             'logs' => LaravelLogViewer::all(),
             'files' => LaravelLogViewer::getFiles(true),
-            'current_file' => LaravelLogViewer::getFileName()
+            'current_file' => LaravelLogViewer::getFileName(),
+            'uri' => $uri
         ]);
     }
 

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -55,7 +55,7 @@
       <p class="text-muted"><i>by Rap2h</i></p>
       <div class="list-group">
         @foreach($files as $file)
-          <a href="?l={{ base64_encode($file) }}"
+          <a href="{{$uri}}&l={{ base64_encode($file)}}"
              class="list-group-item @if ($current_file == $file) llv-active @endif">
             {{$file}}
           </a>


### PR DESCRIPTION
This PR is for maintaining all other query parameters passed when switching log files in the tab. 

One example use case is when the auth parameters is passed in the URL to secure the log files URL.  Current implementation, everytime switching the tabs, the previous query params are omitted.


