### PR TITLE
Fix config_path issue

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -31,7 +31,7 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
                    __DIR__.'/../../views' => base_path('/resources/views/vendor/laravel-log-viewer'),
             ], 'views');
             $this->publishes([
-                __DIR__.'/../../config/logviewer.php' => config_path('logviewer.php'),
+                __DIR__.'/../../config/logviewer.php' => $this->config_path('logviewer.php'),
             ]);
 
         }
@@ -55,6 +55,17 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
     public function provides()
     {
         return array();
+    }
+    
+    /**
+     * Get the configuration path.
+     *
+     * @param  string $path
+     * @return string
+     */
+    private function config_path($path = '')
+    {
+        return function_exists('config_path') ? config_path($path) : app()->basePath() . DIRECTORY_SEPARATOR . 'config' . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 
 }


### PR DESCRIPTION
Fixes #126

Lumen does not have a `config_path` helper, so we have to make our own. Thanks to https://gist.github.com/mabasic/21d13eab12462e596120#gistcomment-2140273 for the correct method to get the config path for Lumen.