### PR TITLE
Implemented optional clickable tr

### DIFF
--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -2,5 +2,5 @@
 
 return [
     'pattern'      => env('LOGVIEWER_PATTERN', '*.log'),
-    'tr_clickable' => env('LOGVIEWER_TR_CLICKABLE', false),
+    'tr_clickable' => env('LOGVIEWER_TR_CLICKABLE', true),
 ];

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -2,5 +2,14 @@
 
 return [
     'pattern'      => env('LOGVIEWER_PATTERN', '*.log'),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Clickable table rows
+    |--------------------------------------------------------------------------
+    |
+    | When this value is set to true the whole <tr> is clickable and will open/close the stacktrace.
+    |
+    */
     'tr_clickable' => env('LOGVIEWER_TR_CLICKABLE', true),
 ];

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    'pattern' => env('LOGVIEWER_PATTERN', '*.log'),
+    'pattern'      => env('LOGVIEWER_PATTERN', '*.log'),
+    'tr_clickable' => env('LOGVIEWER_TR_CLICKABLE', false),
 ];

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -8,7 +8,9 @@ return [
     | Clickable table rows
     |--------------------------------------------------------------------------
     |
-    | When this value is set to true the whole <tr> is clickable and will open/close the stacktrace.
+    | When this value is set to true the whole <tr> is clickable and will 
+    | open/close the stacktrace.
+    | This option is enabled by default.
     |
     */
     'tr_clickable' => env('LOGVIEWER_TR_CLICKABLE', true),

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -144,9 +144,11 @@
 <script type="text/javascript" src="https://cdn.datatables.net/1.10.16/js/dataTables.bootstrap4.min.js"></script>
 <script>
   $(document).ready(function () {
-    $('.table-container tr').on('click', function () {
-      $('#' + $(this).data('display')).toggle();
-    });
+    @if(config('logviewer.tr_clickable', true) === true)
+      $('.table-container tr').on('click', function () {
+        $('#' + $(this).data('display')).toggle();
+      });
+    @endif
     $('#table-log').DataTable({
       "order": [2, 'desc'],
       "stateSave": true,

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -148,6 +148,10 @@
       $('.table-container tr').on('click', function () {
         $('#' + $(this).data('display')).toggle();
       });
+    @else
+      $('.table-container').on('click', '.expand', function () {
+        $('#' + $(this).data('display')).toggle();
+      });
     @endif
     $('#table-log').DataTable({
       "order": [2, 'desc'],


### PR DESCRIPTION
When the tr is fully clickable it is hard to copy some of the exception / context. I added an optional .env variable which can disable the fully clickable functionality.