### PR TITLE
Break on all characters instead of words

### DIFF
--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -59,7 +59,7 @@
     }
 
     .list-group-item {
-      word-wrap: break-all;
+      word-break: break-all;
     }
   </style>
 </head>

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -59,7 +59,7 @@
     }
 
     .list-group-item {
-      word-wrap: break-word;
+      word-wrap: break-all;
     }
   </style>
 </head>


### PR DESCRIPTION
When breaking on words my layout is acting strange. Breaking on all characters fixes this issue.

![log-viewer-break-words](https://user-images.githubusercontent.com/15846780/38613509-6a1662b6-3d8a-11e8-946b-51c9ca8574a6.png)
