### PR TITLE
Adding GLOB_BRACE pattern detection

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -165,7 +165,8 @@ class LaravelLogViewer
      */
     public static function getFiles($basename = false)
     {
-        $files = glob(storage_path() . '/logs/' . (function_exists('config') ? config('logviewer.pattern', '*.log') : '*.log'));
+        $pattern = function_exists('config') ? config('logviewer.pattern', '*.log') : '*.log';
+        $files = glob(storage_path() . '/logs/' . $pattern, preg_match('/\{.*?\,.*?\}/i', $pattern) ? GLOB_BRACE : 0);
         $files = array_reverse($files);
         $files = array_filter($files, 'is_file');
         if ($basename && is_array($files)) {


### PR DESCRIPTION
Added ability to use GLOB_BRACE flag when using the glob() function for the LOGVIEWER_PATTERN.

Useful when using delaycompress in logrotate and not using daily, for example in the logs folder having:
- laravel.log
- laravel.log.1
- laravel.log.2.gz

I can now ignore the gzip file and include the others using this pattern:
- LOGVIEWER_PATTERN=*.{log,log.1}
