### PR TITLE
Read non-standard log format

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -163,13 +163,13 @@ class LaravelLogViewer
             $lines = explode(PHP_EOL, $file);
             $log = [];
 
-            foreach($lines as $line) {
+            foreach($lines as $key => $line) {
                 $log[] = [
                     'context' => '',
                     'level' => '',
                     'level_class' => '',
                     'level_img' => '',
-                    'date' => '',
+                    'date' => $key+1,
                     'text' => $line,
                     'in_file' => null,
                     'stack' => '',

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -125,7 +125,26 @@ class LaravelLogViewer
 
         preg_match_all($pattern, $file, $headings);
 
-        if (!is_array($headings)) return $log;
+        // If log file format appears to be non-standard, just read in each line's content.
+        if (!is_array($headings)) {
+            
+            $lines = explode(PHP_EOL, $file);
+
+            foreach($lines as $line) {
+                $log[] = [
+                    'context' => '',
+                    'level' => '',
+                    'level_class' => '',
+                    'level_img' => '',
+                    'date' => '',
+                    'text' => $line,
+                    'in_file' => null,
+                    'stack' => '',
+                ];
+            }
+
+            return array_reverse($log);
+        }
 
         $log_data = preg_split($pattern, $file);
 

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -125,25 +125,8 @@ class LaravelLogViewer
 
         preg_match_all($pattern, $file, $headings);
 
-        // If log file format appears to be non-standard, just read in each line's content.
         if (!is_array($headings)) {
-            
-            $lines = explode(PHP_EOL, $file);
-
-            foreach($lines as $line) {
-                $log[] = [
-                    'context' => '',
-                    'level' => '',
-                    'level_class' => '',
-                    'level_img' => '',
-                    'date' => '',
-                    'text' => $line,
-                    'in_file' => null,
-                    'stack' => '',
-                ];
-            }
-
-            return array_reverse($log);
+            return $log;
         }
 
         $log_data = preg_split($pattern, $file);
@@ -172,6 +155,25 @@ class LaravelLogViewer
                         );
                     }
                 }
+            }
+        }
+
+        if (!$log) {
+
+            $lines = explode(PHP_EOL, $file);
+            $log = [];
+
+            foreach($lines as $line) {
+                $log[] = [
+                    'context' => '',
+                    'level' => '',
+                    'level_class' => '',
+                    'level_img' => '',
+                    'date' => '',
+                    'text' => $line,
+                    'in_file' => null,
+                    'stack' => '',
+                ];
             }
         }
 

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -39,11 +39,17 @@ class LogViewerController extends BaseController
         $data = [
             'logs' => LaravelLogViewer::all(),
             'files' => LaravelLogViewer::getFiles(true),
-            'current_file' => LaravelLogViewer::getFileName()
+            'current_file' => LaravelLogViewer::getFileName(),
+            'standardFormat' => true,
         ];
 
         if ($this->request->wantsJson()) {
             return $data;
+        }
+
+        $firstLog = reset($data['logs']);
+        if (!$firstLog['context'] && !$firstLog['level']) {
+            $data['standardFormat'] = false;
         }
 
         return app('view')->make('laravel-log-viewer::log', $data);

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -84,12 +84,16 @@
           Log file >50M, please download it.
         </div>
       @else
-        <table id="table-log" class="table table-striped">
+        <table id="table-log" class="table table-striped" data-ordering-index="{{ $standardFormat ? 2 : 0 }}">
           <thead>
           <tr>
-            <th>Level</th>
-            <th>Context</th>
-            <th>Date</th>
+            @if ($standardFormat)
+              <th>Level</th>
+              <th>Context</th>
+              <th>Date</th>
+            @else
+              <th>Line number</th>
+            @endif
             <th>Content</th>
           </tr>
           </thead>
@@ -97,9 +101,11 @@
 
           @foreach($logs as $key => $log)
             <tr data-display="stack{{{$key}}}">
-              <td class="text-{{{$log['level_class']}}}"><span class="fa fa-{{{$log['level_img']}}}"
-                                                               aria-hidden="true"></span> &nbsp;{{$log['level']}}</td>
-              <td class="text">{{$log['context']}}</td>
+              @if ($standardFormat)
+                <td class="text-{{{$log['level_class']}}}"><span class="fa fa-{{{$log['level_img']}}}"
+                                                                aria-hidden="true"></span> &nbsp;{{$log['level']}}</td>
+                <td class="text">{{$log['context']}}</td>
+              @endif
               <td class="date">{{{$log['date']}}}</td>
               <td class="text">
                 @if ($log['stack']) <button type="button" class="float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
@@ -148,7 +154,7 @@
       $('#' + $(this).data('display')).toggle();
     });
     $('#table-log').DataTable({
-      "order": [2, 'desc'],
+      "order": [$('#table-log').data('orderingIndex'), 'desc'],
       "stateSave": true,
       "stateSaveCallback": function (settings, data) {
         window.localStorage.setItem("datatable", JSON.stringify(data));


### PR DESCRIPTION
This fixes #144.

Any non-standard format log files will be displayed as a two column table including line number and content.