### PR TITLE
be able to display "contextual information" of log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Log Viewer for Laravel 5 (compatible with 4.2 too) and Lumen. **Install with com
 
 What ?
 ------
-Small log viewer for laravel. Looks like this:
+Small log viewer for laravel. Also supports displaying context (see "contextual information" of the [document](https://laravel.com/docs/5.6/logging#writing-log-messages)). Looks like this:
 
 ![capture d ecran 2014-12-01 a 10 37 18](https://cloud.githubusercontent.com/assets/1575946/5243642/8a00b83a-7946-11e4-8bad-5c705f328bcc.png)
 
@@ -46,6 +46,21 @@ php artisan vendor:publish \
   --provider="Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider" \
   --tag=views
 ``` 
+
+**Optionally** to enable logging and displaying of context, add the following code into your `app/logging.php`:
+
+```
+'channels' => [
+  // under the channel you use ...
+  'stack' => [
+    // add this "tap" property
+    'tap' => [Rap2hpoutre\LaravelLogViewer\JsonizeMonolog::class],
+    ...
+  ],
+  ...
+]
+...
+```
 
 Install (Lumen)
 ---------------

--- a/src/Rap2hpoutre/LaravelLogViewer/JsonizeMonolog.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/JsonizeMonolog.php
@@ -23,9 +23,8 @@ class JsonizeMonolog
                     'class' => get_class($e),
                     // TODO $e->getPrevious()
                 ];
-                $firstTrace = $e->getTrace()[0];
                 $record['message'] .= ' | ' . get_class($e) .
-                    ": {$e->getMessage()} (code: {$e->getCode()}) at {$firstTrace['file']} ({$firstTrace['line']})";
+                    ": {$e->getMessage()} (code: {$e->getCode()}) at {$e->getFile()} ({$e->getLine()})";
             }
             return $record;
         });

--- a/src/Rap2hpoutre/LaravelLogViewer/JsonizeMonolog.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/JsonizeMonolog.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rap2hpoutre\LaravelLogViewer;
+
+use Monolog\Formatter\JsonFormatter;
+
+class JsonizeMonolog
+{
+    public function __invoke($logger)
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(new JsonFormatter);
+        }
+        $logger->pushProcessor(function ($record) {
+            if (isset($record['context']) && isset($record['context']['exception'])) {
+                $e = $record['context']['exception'];
+                $record['context']['exception'] = [
+                    'message' => $e->getMessage(),
+                    'code' => $e->getCode(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                    'trace' => $e->getTraceAsString(),
+                    'class' => get_class($e),
+                    // TODO $e->getPrevious()
+                ];
+                $firstTrace = $e->getTrace()[0];
+                $record['message'] .= ' | ' . get_class($e) .
+                    ": {$e->getMessage()} (code: {$e->getCode()}) at {$firstTrace['file']} ({$firstTrace['line']})";
+            }
+            return $record;
+        });
+    }
+}

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -1,5 +1,14 @@
 <?php
 
 return [
+    /**
+     * Pattern of log files
+     */
     'pattern' => env('LOGVIEWER_PATTERN', '*.log'),
+
+    /**
+     * Options: line | json
+     * See document for more information
+     */
+    'log_mode' => 'line',
 ];

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -50,7 +50,7 @@ class LogViewerController extends BaseController
         }
 
         $firstLog = reset($data['logs']);
-        if (!$firstLog['context'] && !$firstLog['level']) {
+        if (!$firstLog['channel'] && !$firstLog['level']) {
             $data['standardFormat'] = false;
         }
 

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -92,7 +92,7 @@
           <tbody>
 
           @foreach($logs as $key => $log)
-            <tr class="toggle-trigger" data-display="stack{{{$key}}}" data-display2="extra{{{$key}}}">
+            <tr class="toggle-trigger" data-display="stack{{{$key}}}|extra{{{$key}}}">
               @if ($standardFormat)
                 <td class="text-{{{$log['level_class']}}}"><span class="fa fa-{{{$log['level_img']}}}"
                                                                 aria-hidden="true"></span> &nbsp;{{$log['level']}}</td>
@@ -100,7 +100,7 @@
               @endif
               <td class="date">{{{$log['date']}}}</td>
               <td class="text">
-                @if (isset($log['extra']))<button type="button" class="toggle-trigger float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
+                @if ($log['extra'])<button type="button" class="toggle-trigger float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
                                        data-display="extra{{{$key}}}"><span
                       class="fa fa-sticky-note"></span></button>@endif
                 {{{$log['text']}}}
@@ -114,7 +114,7 @@
                   <div class="stack" id="stack{{{$key}}}"
                        style="display: none; white-space: pre-wrap;">{{{ trim($log['stack']) }}}
                   </div>@endif
-                @if (isset($log['extra']))
+                @if ($log['extra'])
                   <div class="extra" id="extra{{{$key}}}"
                        style="display: none; white-space: pre-wrap;">{!! str_replace(' ','&nbsp;',e($log['extra'])) !!}</div>
                 @endif
@@ -164,8 +164,10 @@
 <script>
   $(document).ready(function () {
     $('.toggle-trigger').on('click', function () {
-      $('#' + $(this).data('display')).toggle();
-      $('#' + $(this).data('display2')).toggle();
+      var ids = $(this).data('display').split('|');
+      for(var i = 0; i < ids.length; ++i) {
+        $('#' + ids[i]).toggle();
+      }
       return false;
     });
     $('#table-log').DataTable({

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -32,7 +32,7 @@
         font-size: 0.7rem;
     }
 
-    .stack {
+    .stack, .extra {
       font-size: 0.85em;
     }
 
@@ -81,7 +81,7 @@
           <tr>
             @if ($standardFormat)
               <th>Level</th>
-              <th>Context</th>
+              <th>Channel</th>
               <th>Date</th>
             @else
               <th>Line number</th>
@@ -92,23 +92,32 @@
           <tbody>
 
           @foreach($logs as $key => $log)
-            <tr data-display="stack{{{$key}}}">
+            <tr class="toggle-trigger" data-display="stack{{{$key}}}" data-display2="extra{{{$key}}}">
               @if ($standardFormat)
                 <td class="text-{{{$log['level_class']}}}"><span class="fa fa-{{{$log['level_img']}}}"
                                                                 aria-hidden="true"></span> &nbsp;{{$log['level']}}</td>
-                <td class="text">{{$log['context']}}</td>
+                <td class="text">{{$log['channel']}}</td>
               @endif
               <td class="date">{{{$log['date']}}}</td>
               <td class="text">
-                @if ($log['stack']) <button type="button" class="float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
+                @if (isset($log['extra']))<button type="button" class="toggle-trigger float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
+                                       data-display="extra{{{$key}}}"><span
+                      class="fa fa-sticky-note"></span></button>@endif
+                {{{$log['text']}}}
+                @if ($log['stack']) <button type="button" class="toggle-trigger float-right expand btn btn-outline-dark btn-sm mb-2 ml-2"
                                        data-display="stack{{{$key}}}"><span
                       class="fa fa-search"></span></button>@endif
-                {{{$log['text']}}}
+
                 @if (isset($log['in_file'])) <br/>{{{$log['in_file']}}}@endif
+
                 @if ($log['stack'])
                   <div class="stack" id="stack{{{$key}}}"
                        style="display: none; white-space: pre-wrap;">{{{ trim($log['stack']) }}}
                   </div>@endif
+                @if (isset($log['extra']))
+                  <div class="extra" id="extra{{{$key}}}"
+                       style="display: none; white-space: pre-wrap;">{!! str_replace(' ','&nbsp;',e($log['extra'])) !!}</div>
+                @endif
               </td>
             </tr>
           @endforeach
@@ -154,8 +163,10 @@
 <script type="text/javascript" src="https://cdn.datatables.net/1.10.16/js/dataTables.bootstrap4.min.js"></script>
 <script>
   $(document).ready(function () {
-    $('.table-container tr').on('click', function () {
+    $('.toggle-trigger').on('click', function () {
       $('#' + $(this).data('display')).toggle();
+      $('#' + $(this).data('display2')).toggle();
+      return false;
     });
     $('#table-log').DataTable({
       "order": [$('#table-log').data('orderingIndex'), 'desc'],


### PR DESCRIPTION
Hello! Thank you for your wonderful job of creating this package!

Monolog has a powerful function that we can not only log a string (message), but also some object called "context" (and another "extra"). It can be seen here: https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md , or here: https://laravel.com/docs/5.6/logging (see the "contextual information" subsection).

Therefore, I think it would be great if this package can display all these contextual information. Here is my PR for it.