### PR TITLE
Add logs route on boot

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -34,6 +34,7 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
                 __DIR__.'/../../config/logviewer.php' => $this->config_path('logviewer.php'),
             ]);
 
+            \Route::get(config('logviewer.uri', 'logs'), '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
         }
     }
 

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -11,4 +11,5 @@ return [
      */
     'pattern' => env('LOGVIEWER_PATTERN', '*.log'),
     'storage_path' => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
+    'uri' => 'logs',
 ];


### PR DESCRIPTION
Registers logs viewer route (`/logs` by default)

This way there is no need to change routes file or conditionally add it in AppServiceProvider.
For example, if you don't want to have log viewer in production, you just add log viewer as dev dependency in composer.json and route is available only in local/test environments.