### PR TITLE
Add MAX_FILE_SIZE to config

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -150,7 +150,8 @@ class LaravelLogViewer
             $this->file = $log_file[0];
         }
 
-        if (app('files')->size($this->file) > self::MAX_FILE_SIZE) {
+        $max_file_size = function_exists('config') ? config('logviewer.max_file_size', self::MAX_FILE_SIZE) : self::MAX_FILE_SIZE;
+        if (app('files')->size($this->file) > $max_file_size) {
             return null;
         }
 

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -1,14 +1,15 @@
 <?php
 
 return [
-     /*
-     |--------------------------------------------------------------------------
-     | Pattern and storage path settings
-     |--------------------------------------------------------------------------
-     |
-     | The env key for pattern and storage path with a default value
-     |
-     */
-    'pattern' => env('LOGVIEWER_PATTERN', '*.log'),
-    'storage_path' => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
+    /*
+    |--------------------------------------------------------------------------
+    | Pattern and storage path settings
+    |--------------------------------------------------------------------------
+    |
+    | The env key for pattern and storage path with a default value
+    |
+    */
+    'max_file_size' => 52428800, // size in Mb
+    'pattern'       => env('LOGVIEWER_PATTERN', '*.log'),
+    'storage_path'  => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
 ];

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -9,7 +9,7 @@ return [
     | The env key for pattern and storage path with a default value
     |
     */
-    'max_file_size' => 52428800, // size in Mb
+    'max_file_size' => 52428800, // size in Byte
     'pattern'       => env('LOGVIEWER_PATTERN', '*.log'),
     'storage_path'  => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
 ];


### PR DESCRIPTION
I'm using this package to view the access log generated by [spatie/laravel-http-logger](https://github.com/spatie/laravel-http-logger) The file size is easily growing. 
After few Mb, the page is not able to render any more.

I think the number of Mb should be the choice of the developer. In my case, I don't need more than 2Mb before I need to download it.