### PR TITLE
Handle empty log array while preparing data to display

### DIFF
--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -72,7 +72,7 @@ class LogViewerController extends BaseController
             return $data;
         }
 
-        if (is_array($data['logs'])) {
+        if (is_array($data['logs']) && count($data['logs']) > 0) {
             $firstLog = reset($data['logs']);
             if (!$firstLog['context'] && !$firstLog['level']) {
                 $data['standardFormat'] = false;


### PR DESCRIPTION
PHP 7.4 throws an error while trying to access array offset on value
of type bool returned by reset() method for empty log