### PR TITLE
Added configuration publishing directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ php artisan vendor:publish \
   --tag=views
 ``` 
 
+**Optionally** publish `logviewer.php` configuration file into `/config/` directory of your app for configuration customization:
+
+```
+php artisan vendor:publish \
+  --provider="Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider"
+``` 
+
 Install (Lumen)
 ---------------
 


### PR DESCRIPTION
A group (a.k.a. tag) should be added in publishing declaration (src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php line 34) to make this clearer.