### PR TITLE
Fix for broken layout issue in #228

### DIFF
--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -52,7 +52,7 @@
     }
 
     .list-group-item {
-      word-wrap: break-word;
+      word-break: break-word;
     }
 
     .folder {


### PR DESCRIPTION
`word-wrap: break-word` is not respected inside the `.list-group-item`. 

Hence `word-break: break-word` is used to allow overriding.