### PR TITLE
Exception thrown if file is not readable

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -155,6 +155,16 @@ class LaravelLogViewer
             return null;
         }
 
+        if (!is_readable($this->file)) {
+            return [[
+                'context' => '',
+                'level' => '',
+                'date' => null,
+                'text' => 'Log file "' . $this->file . '" not readable',
+                'stack' => '',
+            ]];
+        }
+
         $file = app('files')->get($this->file);
 
         preg_match_all($this->pattern->getPattern('logs'), $file, $headings);


### PR DESCRIPTION
In case log file is not readable (generated by some other process, cron etc) exception is thrown.

This PR checks for that and returns message about it as log content.

Thoughts on what would be the best way to make it clear it is an error message from package and not actual log file content?

It would also be possible to mark files as unreadable in file list but that requires checking all files at every load and might not be advisable. Thoughts?