### PR TITLE
Register route on boot (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,27 @@ Install via composer
 composer require rap2hpoutre/laravel-log-viewer
 ```
 
-Add Service Provider to `config/app.php` in `providers` section
+Laravel uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.
+
+### Laravel without auto-discovery:
+
+If you don't use auto-discovery, add the ServiceProvider to the providers array in config/app.php
+
 ```php
 Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider::class,
 ```
 
-Add a route in your web routes file:
+### Adding route
+
+If `LOGVIEWER_REGISTER_ROUTE` is `true` configured route (default `/logs`) is automatically registered.
+You can change it in `logviewer` config.
+
+You can also add the route manually in your web routes file:
 ```php 
 Route::get('logs', '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
 ```
 
-Go to `http://myapp/logs` or some other route
+Go to `http://myapp/logs` or as configured.
 
 ### Install (Lumen)
 Install via composer

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -47,7 +47,8 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        //
+        $configPath = __DIR__ . '/../../config/logviewer.php';
+        $this->mergeConfigFrom($configPath, 'logviewer');
     }
 
     /**

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -33,7 +33,9 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
             $this->publishes([
                 __DIR__.'/../../config/logviewer.php' => $this->config_path('logviewer.php'),
             ]);
+        }
 
+        if (function_exists('config') && config('logviewer.register_route', false)) {
             \Route::get(config('logviewer.uri', 'logs'), '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
         }
     }

--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewerServiceProvider.php
@@ -34,6 +34,7 @@ class LaravelLogViewerServiceProvider extends ServiceProvider {
                 __DIR__.'/../../config/logviewer.php' => $this->config_path('logviewer.php'),
             ]);
 
+            \Route::get(config('logviewer.uri', 'logs'), '\Rap2hpoutre\LaravelLogViewer\LogViewerController@index');
         }
     }
 

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -12,5 +12,9 @@ return [
     'max_file_size' => 52428800, // size in Byte
     'pattern'       => env('LOGVIEWER_PATTERN', '*.log'),
     'storage_path'  => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
-    'uri'           => 'logs',
+
+    // should package register uri for logs
+    // NB! This is a potential security risk if enabled in production
+    'register_route' => env('LOGVIEWER_REGISTER_ROUTE', false),
+    'uri'            => 'logs',
 ];

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -12,4 +12,5 @@ return [
     'max_file_size' => 52428800, // size in Byte
     'pattern'       => env('LOGVIEWER_PATTERN', '*.log'),
     'storage_path'  => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
+    'uri'           => 'logs',
 ];

--- a/tests/LaravelLogViewerTest.php
+++ b/tests/LaravelLogViewerTest.php
@@ -74,13 +74,7 @@ class LaravelLogViewerTest extends OrchestraTestCase
         $this->app = null;
         parent::setUp();
 
-        app('\Illuminate\Foundation\Console\Kernel')
-            ->call('route:list', [], $buffer = new BufferedOutput);
-
-        $this->assertStringNotContainsString(
-            'Rap2hpoutre\\LaravelLogViewer\\LogViewerController@index',
-            $buffer->fetch()
-        );
+        $this->assertSame(0, app()->router->getRoutes()->count());
     }
 
     /** @test */
@@ -90,12 +84,14 @@ class LaravelLogViewerTest extends OrchestraTestCase
         $this->app = null;
         parent::setUp();
 
-        app('\Illuminate\Foundation\Console\Kernel')
-            ->call('route:list', [], $buffer = new BufferedOutput);
-
-        $this->assertStringContainsString(
-            'Rap2hpoutre\\LaravelLogViewer\\LogViewerController@index',
-            $buffer->fetch()
+        $this->assertSame(1, app()->router->getRoutes()->count());
+        $this->assertArrayHasKey('logs', app()->router->getRoutes()->get('GET'));
+        $this->assertSame(
+            [
+                "uses" => "\Rap2hpoutre\LaravelLogViewer\LogViewerController@index",
+                "controller" => "\Rap2hpoutre\LaravelLogViewer\LogViewerController@index",
+            ],
+            app()->router->getRoutes()->get('GET')['logs']->action
         );
     }
 }


### PR DESCRIPTION
Reworked from PR https://github.com/rap2hpoutre/laravel-log-viewer/pull/194

Registers log viewer route automatically if enabled in configuration. Disabled by default.

Setting env variable `LOGVIEWER_REGISTER_ROUTE=true` the package will automatically register a route specified in configuration `logviewer.uri` (default /logs).

This way there is no need to change routes file or conditionally add it in AppServiceProvider.

For example, if you don't want to have log viewer route to be present in some environment (ex: production) there are two possibilities to handle that:

1.  add log viewer as dev dependency in composer.json and use composer `--no-dev` flag so package is not present at all
2. set `LOGVIEWER_REGISTER_ROUTE=false` and route will not be registered by service provider

This way the application code does not have to be changed at all for different environments.
