### PR TITLE
Empty file check before return basenaem

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -138,7 +138,7 @@ class LaravelLogViewer
      */
     public function getFileName()
     {
-        return basename($this->file);
+        return empty($this->file) ? null : basename($this->file);
     }
 
     /**


### PR DESCRIPTION
When there is no log file basename create a warning. Because basename needs a string as the first parameter. 
I checked the empty file and return null otherwise return the file base name. 

Warning: 
laravel.WARNING: basename(): Passing null to parameter #1 ($path) of type string is deprecated in /var/www/vendor/rap2hpoutre/laravel-log-viewer/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php on line 132  