### PR TITLE
Simplify regex matching function greatly

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/Pattern.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/Pattern.php
@@ -4,7 +4,6 @@ namespace Rap2hpoutre\LaravelLogViewer;
 
 /**
  * Class Pattern
- * @property array patterns
  * @package Rap2hpoutre\LaravelLogViewer
  */
 
@@ -12,36 +11,43 @@ class Pattern
 {
 
     /**
-     * @var array
-     */
-    private $patterns = [
-        'logs' => '/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}([\+-]\d{4})?\].*/',
-        'current_log' => [
-            '/^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}([\+-]\d{4})?)\](?:.*?(\w+)\.|.*?)',
-            ': (.*?)( in .*?:[0-9]+)?$/i'
-        ],
-        'files' => '/\{.*?\,.*?\}/i',
-    ];
-
-    /**
      * @return array
      */
     public function all()
     {
-        return array_keys($this->patterns);
+        return array_keys($this->patterns());
+    }
+
+    /**
+     * @param array $options Override default `date` and/or `loglevels` regexes.
+     * @return string[]
+     */
+    protected function patterns($options = [])
+    {
+        $options = array_merge([
+            'date' => '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:[\+-]\d{4})?',
+            'loglevels' => '',
+        ], $options);
+
+        return [
+            // Separate log file into log entries.
+            'logs' => '/\[' . $options['date'] . '\].*(?:\R(?!\[' . $options['date'] . '\]).*)*/',
+
+            // Capture 1: date, 2: context, 3: loglevel 4: message, 5: file.
+            'heading' => '/^\[('. $options['date'] . ')\](?:.*?(\w+)\.|.*?)(' . $options['loglevels'] . '): (.*?)( in .*?:[0-9]+)?$/i',
+
+            'files' => '/\{.*?\,.*?\}/i',
+        ];
     }
 
     /**
      * @param $pattern
-     * @param null $position
+     * @param array $options
      * @return string pattern
      */
-    public function getPattern($pattern, $position = null)
+    public function getPattern($pattern, $options = [])
     {
-        if ($position !== null) {
-            return $this->patterns[$pattern][$position];
-        }
-        return $this->patterns[$pattern];
-        
+        return $this->patterns($options)[$pattern];
+
     }
 }


### PR DESCRIPTION
Initially I encountered an issue where logging `throw new \Exception('failed: test');` would result in the code recognizing 2 log inputs (because of the "failed" word). After trying to debug the issue I found that the whole pattern matching was written very inefficiently so I cleaned up that code and improved the algorithm to a more stable solution, which matches using a much more straightforward technique:

- All log entries start with a date part (e.g. `[2022-09-16 13:19:40]`) up until the next occurrence of any such date string, indicating a new log entry has been encountered
- This log entry is then divided into a _heading_ and a _stacktrace_, simply using a separation on the first linebreak `\n` (which seems to be the default for all monolog entries)

All code should still work for PHP 5.4 (although I havent tested that outdated dependency)