### PR TITLE
fix: getFileName() now returns null if empty filename

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -138,6 +138,10 @@ class LaravelLogViewer
      */
     public function getFileName()
     {
+        if(!$this->file) {
+            return null;
+        }
+
         return basename($this->file);
     }
 


### PR DESCRIPTION
If no log files exist (ie after deleting all files), a deprecation is emited by getFileName function (#277)