### PR TITLE
fix: assignment of object property "request"

### DIFF
--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -37,7 +37,6 @@ class LogViewerController extends BaseController
     public function __construct()
     {
         $this->log_viewer = new LaravelLogViewer();
-        $this->request = app('request');
     }
 
     /**
@@ -46,6 +45,7 @@ class LogViewerController extends BaseController
      */
     public function index()
     {
+        $this->request = app('request');
         $folderFiles = [];
         if ($this->request->input('f')) {
             $this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));


### PR DESCRIPTION
When the program is run as memory resident, the data of the `request` attribute is incorrect. 

For example, using the `laravel` official package `Octane` and enabling the `swoole` extension. The `LogViewerController` object has not been destroyed, so the request parameters read each time are the data assigned at the time of instantiation.