### PR TITLE
fix: prevent insecure deserialization (RCE) and path traversal 

### DIFF
--- a/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
+++ b/src/Rap2hpoutre/LaravelLogViewer/LaravelLogViewer.php
@@ -337,7 +337,7 @@ class LaravelLogViewer
                 $show = last($exploded);
 
                 echo '<div class="list-group folder">
-				    <a href="?f=' . \Illuminate\Support\Facades\Crypt::encrypt($k) . '">
+				    <a href="?f=' . \Illuminate\Support\Facades\Crypt::encryptString($k) . '">
 					    <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span
 						    class="fa fa-folder"></span> ' . $show . '
 				    </a>
@@ -356,7 +356,7 @@ class LaravelLogViewer
 
 
                 echo '<div class="list-group">
-				    <a href="?l=' . \Illuminate\Support\Facades\Crypt::encrypt($file) . '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($folder) . '">
+				    <a href="?l=' . \Illuminate\Support\Facades\Crypt::encryptString($file) . '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($folder) . '">
 					    <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> <span
 						    class="fa fa-file"></span> ' . $show2 . '
 				    </a>

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -48,11 +48,11 @@ class LogViewerController extends BaseController
     {
         $folderFiles = [];
         if ($this->request->input('f')) {
-            $this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));
+            $this->log_viewer->setFolder(basename(Crypt::decryptString($this->request->input('f'))));
             $folderFiles = $this->log_viewer->getFolderFiles(true);
         }
         if ($this->request->input('l')) {
-            $this->log_viewer->setFile(Crypt::decrypt($this->request->input('l')));
+            $this->log_viewer->setFile(basename(Crypt::decryptString($this->request->input('l'))));
         }
 
         if ($early_return = $this->earlyReturn()) {
@@ -95,7 +95,7 @@ class LogViewerController extends BaseController
     private function earlyReturn()
     {
         if ($this->request->input('f')) {
-            $this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));
+            $this->log_viewer->setFolder(basename(Crypt::decryptString($this->request->input('f'))));
         }
 
         if ($this->request->input('dl')) {
@@ -125,7 +125,7 @@ class LogViewerController extends BaseController
      */
     private function pathFromInput($input_string)
     {
-        return $this->log_viewer->pathToLogFile(Crypt::decrypt($this->request->input($input_string)));
+        return $this->log_viewer->pathToLogFile(basename(Crypt::decryptString($this->request->input($input_string))));
     }
 
     /**

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -191,7 +191,7 @@
           </div>
         @endforeach
         @foreach($files as $file)
-          <a href="?l={{ \Illuminate\Support\Facades\Crypt::encrypt($file) }}"
+          <a href="?l={{ \Illuminate\Support\Facades\Crypt::encryptString($file) }}"
              class="list-group-item @if ($current_file == $file) llv-active @endif">
             {{$file}}
           </a>
@@ -254,20 +254,20 @@
       @endif
       <div class="p-3">
         @if($current_file)
-          <a href="?dl={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}">
+          <a href="?dl={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
             <span class="fa fa-download"></span> Download file
           </a>
           -
-          <a id="clean-log" href="?clean={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}">
+          <a id="clean-log" href="?clean={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
             <span class="fa fa-sync"></span> Clean file
           </a>
           -
-          <a id="delete-log" href="?del={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}">
+          <a id="delete-log" href="?del={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
             <span class="fa fa-trash"></span> Delete file
           </a>
           @if(count($files) > 1)
             -
-            <a id="delete-all-log" href="?delall=true{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}">
+            <a id="delete-all-log" href="?delall=true{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
               <span class="fa fa-trash-alt"></span> Delete all files
             </a>
           @endif


### PR DESCRIPTION
Fix #310
Fix #306

## Context

Both vulnerabilities share the same attack surface: the query parameters are user supplied encrypted values that the controller decrypts and uses as file/folder paths with no further validation. An attacker who knows for any reasons the `APP_KEY` can forge arbitrary values for any of these parameters.

## Vulnerabilities & Fixes

### #310 Insecure Deserialization (RCE)

`Crypt::encrypt()` / `Crypt::decrypt()` call `serialize()` / `unserialize()` under the hood. An attacker can encrypt a serialized PHP gadget chain with the `APP_KEY` and pass it as a query parameter. When the controller calls `Crypt::decrypt()`, PHP instantiates the attacker-controlled object and triggers `__wakeup()` / `__destruct()` which is leading to Remote Code Execution.

**Fix:** replace `Crypt::encrypt()` / `Crypt::decrypt()` with `Crypt::encryptString()` / `Crypt::decryptString()`. The `*String` variants skip serialization entirely. 

### #306 Path Traversal

`pathToLogFile()` contains an early return that serves any file that exists on disk:

```php
if (app('files')->exists($file)) { // try the absolute path
    return $file;
}
```

An attacker can encrypt an absolute path (e.g. `/etc/passwd`, `/var/www/.env`) with the `APP_KEY` and pass it as `?dl=` to download it, or as `?del=` to delete it.

**Fix:** wrap every `Crypt::decryptString()` call with `basename()`, which strips any directory component before the value reaches `pathToLogFile()`.

```php
// before
$this->log_viewer->setFile(Crypt::decryptString($this->request->input('l')));

// after
$this->log_viewer->setFile(basename(Crypt::decryptString($this->request->input('l'))));
```

## Breaking Change (Minor)

`encryptString` and `encrypt` produce different ciphertext formats. Existing client's browser bookmarked or cached URLs will produce a `DecryptException` after this update, so users just need to reload the log viewer to get fresh links for bookmarking and so on. No log data is lost.

## References

- https://laravel.com/docs/13.x/encryption#using-the-encrypter

