### PR TITLE
feat: configurable visibility for log action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ php artisan vendor:publish \
   --provider="Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider"
 ``` 
 
+### Button visibility
+Show/hide buttons via the `buttons` array in the published config, or the matching env vars (all default to `true`):
+
+```php
+'buttons' => [
+    'download'   => true, // LOGVIEWER_BTN_DOWNLOAD
+    'clean'      => true, // LOGVIEWER_BTN_CLEAN
+    'delete'     => true, // LOGVIEWER_BTN_DELETE
+    'delete_all' => true, // LOGVIEWER_BTN_DELETE_ALL
+],
+```
+
 ### Troubleshooting
 If you got a `InvalidArgumentException in FileViewFinder.php` error, it may be a problem with config caching. Double check installation, then run `php artisan config:clear`.
 

--- a/src/config/logviewer.php
+++ b/src/config/logviewer.php
@@ -12,4 +12,21 @@ return [
     'max_file_size' => 52428800, // size in Byte
     'pattern'       => env('LOGVIEWER_PATTERN', '*.log'),
     'storage_path'  => env('LOGVIEWER_STORAGE_PATH', storage_path('logs')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Button visibility
+    |--------------------------------------------------------------------------
+    |
+    | Toggle the buttons/controls displayed in the log viewer UI. Set any of
+    | these to false to hide the corresponding control. All default to true
+    | to preserve the original behaviour.
+    |
+    */
+    'buttons' => [
+        'download'   => env('LOGVIEWER_BTN_DOWNLOAD', true),
+        'clean'      => env('LOGVIEWER_BTN_CLEAN', true),
+        'delete'     => env('LOGVIEWER_BTN_DELETE', true),
+        'delete_all' => env('LOGVIEWER_BTN_DELETE_ALL', true),
+    ],
 ];

--- a/src/controllers/LogViewerController.php
+++ b/src/controllers/LogViewerController.php
@@ -98,15 +98,15 @@ class LogViewerController extends BaseController
             $this->log_viewer->setFolder(basename(Crypt::decryptString($this->request->input('f'))));
         }
 
-        if ($this->request->input('dl')) {
+        if ($this->request->input('dl') && config('logviewer.buttons.download', true)) {
             return $this->download($this->pathFromInput('dl'));
-        } elseif ($this->request->has('clean')) {
+        } elseif ($this->request->has('clean') && config('logviewer.buttons.clean', true)) {
             app('files')->put($this->pathFromInput('clean'), '');
             return $this->redirect(url()->previous());
-        } elseif ($this->request->has('del')) {
+        } elseif ($this->request->has('del') && config('logviewer.buttons.delete', true)) {
             app('files')->delete($this->pathFromInput('del'));
             return $this->redirect($this->request->url());
-        } elseif ($this->request->has('delall')) {
+        } elseif ($this->request->has('delall') && config('logviewer.buttons.delete_all', true)) {
             $files = ($this->log_viewer->getFolderName())
                         ? $this->log_viewer->getFolderFiles(true)
                         : $this->log_viewer->getFiles(true);

--- a/src/views/log.blade.php
+++ b/src/views/log.blade.php
@@ -254,19 +254,32 @@
       @endif
       <div class="p-3">
         @if($current_file)
-          <a href="?dl={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
-            <span class="fa fa-download"></span> Download file
-          </a>
-          -
-          <a id="clean-log" href="?clean={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
-            <span class="fa fa-sync"></span> Clean file
-          </a>
-          -
-          <a id="delete-log" href="?del={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
-            <span class="fa fa-trash"></span> Delete file
-          </a>
-          @if(count($files) > 1)
-            -
+          @php $sep = ''; @endphp
+          @if(config('logviewer.buttons.download', true))
+            <a href="?dl={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
+              <span class="fa fa-download"></span> Download file
+            </a>
+            @php $sep = '-'; @endphp
+          @endif
+
+          @if(config('logviewer.buttons.clean', true))
+            {{ $sep }}
+            <a id="clean-log" href="?clean={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
+              <span class="fa fa-sync"></span> Clean file
+            </a>
+            @php $sep = '-'; @endphp
+          @endif
+
+          @if(config('logviewer.buttons.delete', true))
+            {{ $sep }}
+            <a id="delete-log" href="?del={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
+              <span class="fa fa-trash"></span> Delete file
+            </a>
+            @php $sep = '-'; @endphp
+          @endif
+
+          @if(count($files) > 1 && config('logviewer.buttons.delete_all', true))
+            {{ $sep }}
             <a id="delete-all-log" href="?delall=true{{ ($current_folder) ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
               <span class="fa fa-trash-alt"></span> Delete all files
             </a>

--- a/tests/LogViewerButtonsTest.php
+++ b/tests/LogViewerButtonsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Rap2hpoutre\LaravelLogViewer\Tests;
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\File;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider;
+use Rap2hpoutre\LaravelLogViewer\LogViewerController;
+
+/**
+ * Tests for config-driven button visibility (backend enforcement).
+ *
+ * @package Rap2hpoutre\LaravelLogViewer
+ */
+class LogViewerButtonsTest extends OrchestraTestCase
+{
+    /**
+     * @var string
+     */
+    private $logFile = 'buttons-test.log';
+
+    protected function getPackageProviders($app)
+    {
+        return [LaravelLogViewerServiceProvider::class];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+    }
+
+    protected function defineRoutes($router)
+    {
+        $router->get('logs', [LogViewerController::class, 'index']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::ensureDirectoryExists(storage_path('logs'));
+        File::put($this->logPath(), '[2018-09-05 20:20:51] local.ERROR: Something went wrong');
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->logPath());
+        parent::tearDown();
+    }
+
+    private function logPath(): string
+    {
+        return storage_path('logs/' . $this->logFile);
+    }
+
+    private function encrypted(): string
+    {
+        return Crypt::encryptString($this->logFile);
+    }
+
+    public function testDeleteRemovesFileWhenEnabled()
+    {
+        config()->set('logviewer.buttons.delete', true);
+
+        $this->get('logs?del=' . $this->encrypted());
+
+        $this->assertFileDoesNotExist($this->logPath());
+    }
+
+    public function testDeleteKeepsFileWhenDisabled()
+    {
+        config()->set('logviewer.buttons.delete', false);
+
+        $this->getJson('logs?del=' . $this->encrypted());
+
+        $this->assertFileExists($this->logPath());
+    }
+
+    public function testCleanEmptiesFileWhenEnabled()
+    {
+        config()->set('logviewer.buttons.clean', true);
+
+        $this->get('logs?clean=' . $this->encrypted());
+
+        $this->assertFileExists($this->logPath());
+        $this->assertSame('', File::get($this->logPath()));
+    }
+
+    public function testCleanKeepsContentWhenDisabled()
+    {
+        config()->set('logviewer.buttons.clean', false);
+
+        $this->getJson('logs?clean=' . $this->encrypted());
+
+        $this->assertNotSame('', File::get($this->logPath()));
+    }
+
+    public function testDeleteAllRemovesFilesWhenEnabled()
+    {
+        config()->set('logviewer.buttons.delete_all', true);
+
+        $this->get('logs?delall=true');
+
+        $this->assertFileDoesNotExist($this->logPath());
+    }
+
+    public function testDeleteAllKeepsFilesWhenDisabled()
+    {
+        config()->set('logviewer.buttons.delete_all', false);
+
+        $this->getJson('logs?delall=true');
+
+        $this->assertFileExists($this->logPath());
+    }
+}


### PR DESCRIPTION
Add a `buttons` config array (with matching env vars) to show/hide the Download, Clean, Delete and Delete-all controls in the log viewer.

- config/logviewer.php: new `buttons` array, all default to true
- views/log.blade.php: each button gated behind its config flag
- controllers/LogViewerController.php: backend enforcement so disabled actions cannot be triggered via direct URL access
- tests: cover backend enforcement for each action (enabled + disabled)
- README: document the new options